### PR TITLE
Gulpfileの修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,22 +4,28 @@ const gulp = require('gulp');
 const sass = require('gulp-sass');
   
 // style.scssの監視タスクを作成する
+// Watchの場合は別タスクに分けてあげて、別途[タスク名]で指定してあげると動くよ
+// 一度に複数のタスクを実行する場合は ['タスク名', 'タスク名2'] 的な感じで増やせる
 gulp.task('default', function () {
   // ★ style.scssファイルを監視
-  gulp.watch('scss/style.scss', function () {
-    // style.scssの更新があった場合の処理
-  
-    // style.scssファイルを取得
-    gulp.src('scss/style.scss')
-      // Sassのコンパイルを実行
-      .pipe(sass({
-        outputStyle: 'expanded'
-      })
-      // Sassのコンパイルエラーを表示
-      // (これがないと自動的に止まってしまう)
-      .on('error', sass.logError))
-      // cssフォルダー以下に保存
-      .pipe(gulp.dest('scss'));
-  });
+  // ** -> どんな名前のディレクトリでも条件に満たす
+  // *.scss -> 拡張子が.scssで終わるもの全て
+  // scss/**/*.scss -> scssディレクトリ以下の全てのディレクトリかつ.scssで終わるものに変更があった場合
+  // [タスク名] を実行する
+  gulp.watch('scss/**/*.scss',['scss']);
+});
+
+gulp.task('scss', function() {
+  // style.scssファイルを取得
+  gulp.src('scss/**/*.scss')
+  // Sassのコンパイルを実行
+  .pipe(sass({
+    outputStyle: 'expanded'
+  })
+  // Sassのコンパイルエラーを表示
+  // (これがないと自動的に止まってしまう)
+  .on('error', sass.logError))
+  // cssフォルダー以下に保存
+  .pipe(gulp.dest('scss'))
 });
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "index.js",
   "scripts": {
     "gulp": "gulp",
-    "build": "gulp build",
-    "prod": "gulp prod",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
`gulpfile.js` にコメントを残してます。
https://github.com/gulpjs/gulp/blob/v3.9.1/docs/API.md#gulpwatchglob-opts-tasks

これに沿って、`scss` タスクに分割してwatchで `scss` タスクを実行するようにしてます。
ターミナル上は `npm run gulp` で `default` タスクが走ってwatch状態になりまーす。